### PR TITLE
Prevent flake8 issues on other Python 3 versions

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements_flake8.txt
+++ b/{{cookiecutter.project_slug}}/requirements_flake8.txt
@@ -1,4 +1,4 @@
 flake8==3.5.0
 {% if cookiecutter.use_flake8_plugins == 'y' -%}
 flake8-docstrings==1.3.0
-darglint==0.5.2{% endif %}
+darglint==0.5.2; python_version >= "3.6"{% endif %}


### PR DESCRIPTION
Limit darglint to python versions >= 3.6